### PR TITLE
fix: sanitise CQL text query

### DIFF
--- a/confluence/provider/client.py
+++ b/confluence/provider/client.py
@@ -110,8 +110,11 @@ class ConfluenceClient:
     def search_pages(self, query):
         search_url = f"{self.base_url}/wiki/rest/api/content/search"
 
+        # Substitutes any sequence of non-alphanumeric or whitespace characters with a whitespace
+        formatted_query = re.sub("\W+", " ", query)
+
         params = {
-            "cql": f'text ~ "%s"' % re.sub("\W+", " ", query),
+            "cql": f'text ~ "{formatted_query}"',
             "limit": self.search_limit,
         }
 

--- a/confluence/provider/client.py
+++ b/confluence/provider/client.py
@@ -3,6 +3,7 @@ import aiohttp
 import base64
 import functools
 import logging
+import re
 import requests
 import sys
 
@@ -109,7 +110,10 @@ class ConfluenceClient:
     def search_pages(self, query):
         search_url = f"{self.base_url}/wiki/rest/api/content/search"
 
-        params = {"cql": f"text ~ {query}", "limit": self.search_limit}
+        params = {
+            "cql": f'text ~ "%s"' % re.sub("\W+", " ", query),
+            "limit": self.search_limit,
+        }
 
         response = requests.get(
             search_url,


### PR DESCRIPTION
### What's being changed:

When submitting a `CQL` query to the confluence API, the queries failed if a white space character was included in the query (for example "BBQ Grill" would cause an error like

```
ERROR:provider.app:Upstream search error: Error during Confluence search: {"statusCode":400,"data":{"authorized":true,"valid":true,"errors":[],"successful":true},"message":"com.atlassian.confluence.api.servic
e.exceptions.BadRequestException: No field exists with the name: 'Grill'"}
```

looking closer at the code showed that the queries were being passed without quotes (the cause of the issue). 

### How did you test this change (include any code snippets, API requests, screenshots, or gifs):

The queries are now passed to CQL 

* adds `"` quote characters around the query string passed to CQL
* using `%s` string formatting rather than f-string formatting (to avoid [injection attacks](https://help.securityjourney.com/en/articles/6719498-python-string-formatting-and-sql-injection-attacks)
* uses a regex to strip out exotic characters and pass a simple string