### PR TITLE
feat: return page URL

### DIFF
--- a/confluence/provider/client.py
+++ b/confluence/provider/client.py
@@ -96,10 +96,12 @@ class ConfluenceClient:
 
             content = await response.json()
 
+            page_url = f"{self.base_url}/wiki{content['_links']['webui']}"
+
             serialized_page = {
                 "title": content["title"],
                 "text": content["body"][self.PAGE_BODY_FORMAT]["value"],
-                "url": get_page_by_id_url,
+                "url": page_url,
             }
 
             # Update cache


### PR DESCRIPTION
### What's being changed:

The `url` returned by the confluence response points to the API endpoint which isn't very helpful to end users. This PR changes the URL to point to the human friendly web page in confluence. 