### PR TITLE
force api key to be a string

### DIFF
--- a/_template_/provider/app.py
+++ b/_template_/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 # This function is run for all endpoints to ensure requests are using a valid API key
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/agilitycms/provider/app.py
+++ b/agilitycms/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/agora/provider/app.py
+++ b/agora/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/aha/provider/app.py
+++ b/aha/provider/app.py
@@ -25,7 +25,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/algolia/provider/app.py
+++ b/algolia/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/asana/provider/app.py
+++ b/asana/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/atera/provider/app.py
+++ b/atera/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/backstage/provider/app.py
+++ b/backstage/provider/app.py
@@ -24,7 +24,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/basecamp/provider/app.py
+++ b/basecamp/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/bigquery/provider/app.py
+++ b/bigquery/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/blogger/provider/app.py
+++ b/blogger/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/box/provider/app.py
+++ b/box/provider/app.py
@@ -21,7 +21,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/carbon/provider/app.py
+++ b/carbon/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/cockroach/provider/app.py
+++ b/cockroach/provider/app.py
@@ -24,7 +24,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/coda/provider/app.py
+++ b/coda/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/confluence/provider/app.py
+++ b/confluence/provider/app.py
@@ -23,7 +23,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/contentful/provider/app.py
+++ b/contentful/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/copper/provider/app.py
+++ b/copper/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/couchbase/provider/app.py
+++ b/couchbase/provider/app.py
@@ -23,7 +23,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/courier/provider/app.py
+++ b/courier/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/crunchbase/provider/app.py
+++ b/crunchbase/provider/app.py
@@ -25,7 +25,7 @@ def search(body):
 
 # This function is run for all endpoints to ensure requests are using a valid API key
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/discourse/provider/app.py
+++ b/discourse/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/docusign/provider/app.py
+++ b/docusign/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/dropbox/provider/app.py
+++ b/dropbox/provider/app.py
@@ -28,7 +28,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/egnyte/provider/app.py
+++ b/egnyte/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/elastic/provider/app.py
+++ b/elastic/provider/app.py
@@ -21,7 +21,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/fifteenfive/provider/app.py
+++ b/fifteenfive/provider/app.py
@@ -23,7 +23,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/fireflies/provider/app.py
+++ b/fireflies/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/freshdesk/provider/app.py
+++ b/freshdesk/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/freshsales/provider/app.py
+++ b/freshsales/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/freshservice/provider/app.py
+++ b/freshservice/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/gcalendar/provider/app.py
+++ b/gcalendar/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/gdrive/provider/app.py
+++ b/gdrive/provider/app.py
@@ -31,7 +31,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/github/provider/app.py
+++ b/github/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/gitlab/provider/app.py
+++ b/gitlab/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/gmail/provider/app.py
+++ b/gmail/provider/app.py
@@ -21,7 +21,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/guru/provider/app.py
+++ b/guru/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/hackernews/provider/app.py
+++ b/hackernews/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
 
     if api_key != "" and token != api_key:
         raise Unauthorized()

--- a/helpscout/provider/app.py
+++ b/helpscout/provider/app.py
@@ -21,7 +21,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/hubspot/provider/app.py
+++ b/hubspot/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/intercom/provider/app.py
+++ b/intercom/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/jenkins/provider/app.py
+++ b/jenkins/provider/app.py
@@ -24,7 +24,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/jira/provider/app.py
+++ b/jira/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/kendra/provider/app.py
+++ b/kendra/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/klaviyo/provider/app.py
+++ b/klaviyo/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/knowledgeowl/provider/app.py
+++ b/knowledgeowl/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/linear/provider/app.py
+++ b/linear/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/medium/provider/app.py
+++ b/medium/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/milvus/provider/app.py
+++ b/milvus/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/miro/provider/app.py
+++ b/miro/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/mongodb/provider/app.py
+++ b/mongodb/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/msteams/provider/app.py
+++ b/msteams/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/mysql/provider/app.py
+++ b/mysql/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/notion/provider/app.py
+++ b/notion/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/opensearch/provider/app.py
+++ b/opensearch/provider/app.py
@@ -28,7 +28,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/opsgenie/provider/app.py
+++ b/opsgenie/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/outlook/provider/app.py
+++ b/outlook/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/pagerduty/provider/app.py
+++ b/pagerduty/provider/app.py
@@ -28,7 +28,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/pinecone/provider/app.py
+++ b/pinecone/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/postgres/provider/app.py
+++ b/postgres/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/qdrant/provider/app.py
+++ b/qdrant/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/readme/provider/app.py
+++ b/readme/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/redis/provider/app.py
+++ b/redis/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/redshift/provider/app.py
+++ b/redshift/provider/app.py
@@ -28,7 +28,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/reuters/provider/app.py
+++ b/reuters/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/servicenow/provider/app.py
+++ b/servicenow/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/sharepoint/provider/app.py
+++ b/sharepoint/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/shortcut/provider/app.py
+++ b/shortcut/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
 
     return {}

--- a/skilljar/provider/app.py
+++ b/skilljar/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/slack/provider/app.py
+++ b/slack/provider/app.py
@@ -23,7 +23,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/slack/provider/client.py
+++ b/slack/provider/client.py
@@ -19,7 +19,7 @@ class SlackClient:
 
 
 def get_client():
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     api_token = None
     if api_key == "":
         api_token = get_access_token()

--- a/smartsheet/provider/app.py
+++ b/smartsheet/provider/app.py
@@ -21,7 +21,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/snowflake/provider/app.py
+++ b/snowflake/provider/app.py
@@ -23,7 +23,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/solr/provider/app.py
+++ b/solr/provider/app.py
@@ -24,7 +24,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/stackoverflow/provider/app.py
+++ b/stackoverflow/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/techcrunch/provider/app.py
+++ b/techcrunch/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/trello/provider/app.py
+++ b/trello/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/vectara/provider/app.py
+++ b/vectara/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != str(app.config.get("CONNECTOR_API_KEY")):
+    if token != str(str(app.config.get("CONNECTOR_API_KEY"))):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/vespa/provider/app.py
+++ b/vespa/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/weaviate/provider/app.py
+++ b/weaviate/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/wikipedia/provider/app.py
+++ b/wikipedia/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/wordpress/provider/app.py
+++ b/wordpress/provider/app.py
@@ -22,7 +22,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/yammer/provider/app.py
+++ b/yammer/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/yext/provider/app.py
+++ b/yext/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
     # successfully authenticated

--- a/youtrack/provider/app.py
+++ b/youtrack/provider/app.py
@@ -19,7 +19,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    api_key = app.config.get("CONNECTOR_API_KEY", "")
+    api_key = str(app.config.get("CONNECTOR_API_KEY", ""))
     if api_key != "" and token != api_key:
         raise Unauthorized()
 

--- a/zendesk/provider/app.py
+++ b/zendesk/provider/app.py
@@ -26,7 +26,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}

--- a/zulip/provider/app.py
+++ b/zulip/provider/app.py
@@ -18,7 +18,7 @@ def search(body):
 
 
 def apikey_auth(token):
-    if token != app.config.get("CONNECTOR_API_KEY"):
+    if token != str(app.config.get("CONNECTOR_API_KEY")):
         raise Unauthorized()
     # successfully authenticated
     return {}


### PR DESCRIPTION
<!--
Thanks for contributing to Cohere's Search Connectors. Please fill out as much information in this template as you can so we can review the changes made. If you are a new contributor, please make sure you've read our CONTRIBUTING file located in the root directory.
-->

### What's being changed:

Connector_api_key is being forced to a string now. If the env contains only digits, it becomes a number which will never match the bearer token comparison.

### How did you test this change (include any code snippets, API requests, screenshots, or gifs):

<!-- Please include details of your testing here. Such as screenshots of your terminal, copy/paste of a request response, etc. -->
