### PR TITLE
[GDrive] Escape apostrophes in search queries

### DIFF
--- a/gdrive/provider/provider.py
+++ b/gdrive/provider/provider.py
@@ -108,6 +108,10 @@ def request_credentials(access_token=None):
         raise AssertionError("No service account or oauth credentials provided")
 
 
+def escape(text: str) -> str:
+    return text.replace("'", "\\'")
+
+
 def search(query, access_token=None):
     service = build("drive", "v3", credentials=request_credentials(access_token))
 
@@ -121,7 +125,7 @@ def search(query, access_token=None):
         + " or ".join([f"mimeType = '{mime_type}'" for mime_type in SEARCH_MIME_TYPES])
         + ")",
         "("
-        + " or ".join([f"fullText contains '{word}'" for word in query_words])
+        + " or ".join([f"fullText contains '{escape(word)}'" for word in query_words])
         + ")",
     ]
 


### PR DESCRIPTION
### What's being changed:

The construction of the search query sent to the Google Drive API is being changed to escape apostrophes in the query received by the connector.

### How did you test this change (include any code snippets, API requests, screenshots, or gifs):

I tested this in Coral with a Google Drive connector set up, pointing to my localhost via ngrok. Prior to this change queries containing an apostrophe caused the gdrive connector to get a 400 Bad Request error when sending the query to the Google API. With the change in this PR, it no longer gives an error.

I have also tested the connector directly by sending requests to it from HTTPie, containing apostrophes in the query.

The following link to the Google Docs shows that this is the correct way to escape an apostrophe:

https://developers.google.com/drive/api/guides/ref-search-terms#file-properties

It specifically says to send the query quoted with single quotes, and to escape any single quote in the query with a `\` (as opposed to quoting the query in double quotes, for example).
